### PR TITLE
Fix crash on trying to linkify

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
       opts.author = utils.parseAuthor(opts.author);
     }
 
-    if (opts.linkify === true) {
+    if (opts.linkify === true && opts.author.url) {
       var origAuthor = opts.author.name;
       opts.author = utils.link(opts.author.name, opts.author.url);
     } else {


### PR DESCRIPTION
npm allows `author` clause to be a string and not a structure with `url` defined in it so when trying to linkify we need to check for the existence of url (otherwise `utils.link` throws)